### PR TITLE
Update tailed types and declarations, README.md, and example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ root
 |-- pkgs
 |   `-- pkg1~0.0.0.zip
 `-- src
-     +-- Main.eth
+    `-- Main.eth
 ```
 
 ### Project File

--- a/example/eth.yaml
+++ b/example/eth.yaml
@@ -2,3 +2,4 @@ name: "example"
 version: "0.0.0"
 packages:
   std: "0.0.0"
+  example_package: "0.0.0"

--- a/src/ast/decl/abstract.go
+++ b/src/ast/decl/abstract.go
@@ -51,13 +51,13 @@ func (a *Abstract) Syntax(p ast.SyntaxParser) io.Error {
 		return err
 	}
 
-	if p.Match(token.TOK_TILDE) {
-		a.IsTailed = true
-	}
-
 	a.GenericConstraints, err = syntaxGenericConstraints(p)
 	if err != nil {
 		return err
+	}
+
+	if p.Match(token.TOK_TILDE) {
+		a.IsTailed = true
 	}
 
 	if p.Match(token.TOK_SUBTYPE) {

--- a/src/ast/decl/class.go
+++ b/src/ast/decl/class.go
@@ -64,13 +64,13 @@ func (c *Class) Syntax(p ast.SyntaxParser) io.Error {
 		return err
 	}
 
-	if p.Match(token.TOK_TILDE) {
-		c.IsTailed = true
-	}
-
 	c.GenericConstraints, err = syntaxGenericConstraints(p)
 	if err != nil {
 		return err
+	}
+
+	if p.Match(token.TOK_TILDE) {
+		c.IsTailed = true
 	}
 
 	if p.Match(token.TOK_SUBTYPE) {

--- a/src/ast/decl/struct.go
+++ b/src/ast/decl/struct.go
@@ -48,13 +48,13 @@ func (s *Struct) Syntax(p ast.SyntaxParser) io.Error {
 		return err
 	}
 
-	if p.Match(token.TOK_TILDE) {
-		s.IsTailed = true
-	}
-
 	s.GenericConstraints, err = syntaxGenericConstraints(p)
 	if err != nil {
 		return err
+	}
+
+	if p.Match(token.TOK_TILDE) {
+		s.IsTailed = true
 	}
 
 	if _, err := p.Consume(token.TOK_LEFTBRACE); err != nil {

--- a/src/ast/type_/composite.go
+++ b/src/ast/type_/composite.go
@@ -5,9 +5,6 @@ import (
 	"geth-cody/ast"
 	"geth-cody/compile/lexer/token"
 	"geth-cody/io"
-	"math"
-
-	"go.uber.org/zap"
 )
 
 type Composite struct {
@@ -43,20 +40,7 @@ func (c *Composite) Syntax(p ast.SyntaxParser) (ast.Type, io.Error) {
 		c.Tokens = append(c.Tokens, tok)
 	}
 
-	var t ast.Type = c
-	if p.Match(token.TOK_TILDE) {
-		size := int64(-1)
-		if p.Match(token.TOK_INTEGER) {
-			tok := p.Prev()
-			if tok.Integer > math.MaxInt {
-				return nil, io.NewError("type tail size is larger than max signed integer limit", zap.Any("token", tok))
-			}
-			size = int64(tok.Integer)
-		}
-		t = &Tailed{Type: t, Size: size, EndToken: p.Prev()}
-	}
-
-	return t, nil
+	return c, nil
 }
 
 func (c *Composite) ExtendsAsPointer(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {


### PR DESCRIPTION
Move the `~` in tailed types to after any generic type arguments.
Before: 
```
var Node~5[int] n1;
var *Node~[int] n2;
```
After:
```
var Node[int]~5 n1;
var *Node[int]~ n2;
```

Updated README directory example.
Updated example directory with spoofed zipped package.