### PR TITLE
Update types to include type context

### DIFF
--- a/src/ast/decl/abstract.go
+++ b/src/ast/decl/abstract.go
@@ -100,7 +100,7 @@ func (a *Abstract) LinkParents(p ast.SemanticParser, visitedDecls *data.AsyncSet
 	defer delete(cycleMap, l.String())
 
 	for _, parent := range a.Implements {
-		parentDecl, err := parent.Declaration(p.TypeContext())
+		parentDecl, err := parent.Declaration()
 		if err != nil {
 			return err
 		}
@@ -144,9 +144,6 @@ func (a *Abstract) LinkParents(p ast.SemanticParser, visitedDecls *data.AsyncSet
 }
 
 func (a *Abstract) Semantic(p ast.SemanticParser) io.Error {
-	p.WrapTypeContext(a)
-	defer p.UnwrapTypeContext()
-
 	// TODO: Handle generic constraints
 	return a.BaseDecl.Semantic(p)
 }

--- a/src/ast/decl/class.go
+++ b/src/ast/decl/class.go
@@ -116,7 +116,7 @@ func (c *Class) LinkParents(p ast.SemanticParser, visitedDecls *data.AsyncSet[as
 	defer delete(cycleMap, l.String())
 
 	for _, parent := range c.Implements {
-		parentDecl, err := parent.Declaration(p.TypeContext())
+		parentDecl, err := parent.Declaration()
 		if err != nil {
 			return err
 		}
@@ -154,9 +154,6 @@ func (c *Class) LinkParents(p ast.SemanticParser, visitedDecls *data.AsyncSet[as
 }
 
 func (c *Class) Semantic(p ast.SemanticParser) io.Error {
-	p.WrapTypeContext(c)
-	defer p.UnwrapTypeContext()
-
 	// TODO: Handle generic constraints
 	return c.BaseDecl.Semantic(p)
 }

--- a/src/ast/decl/decl.go
+++ b/src/ast/decl/decl.go
@@ -2,6 +2,7 @@ package decl
 
 import (
 	"geth-cody/ast"
+	"geth-cody/ast/type_"
 	"geth-cody/compile/data"
 	"geth-cody/compile/lexer/token"
 	"geth-cody/io"
@@ -168,6 +169,9 @@ func Syntax(p ast.SyntaxParser) (ast.Declaration, io.Error) {
 		return nil, io.NewError("expected declaration", zap.Any("token", t))
 	}
 
+	p.WrapScope(declaration)
+	defer p.UnwrapScope()
+
 	if err := declaration.Syntax(p); err != nil {
 		return nil, err
 	}
@@ -211,7 +215,7 @@ func (d *BaseDecl) LinkParents(p ast.SemanticParser, visitedDecls *data.AsyncSet
 func (child *BaseDecl) Extends(p ast.SemanticParser, parent ast.Declaration, visitedDecls *data.AsyncSet[ast.Declaration]) io.Error {
 	for name, parentMethod := range parent.Methods() {
 		if childMethod, exists := child.Methods_[name]; exists {
-			if _, err := p.TypeContext().MustExtend(childMethod.Type(), parentMethod.Type()); err != nil {
+			if _, err := type_.MustExtend(childMethod.Type(), parentMethod.Type()); err != nil {
 				return err
 			}
 		} else if parentMethod.HasModifier(ast.MOD_VIRTUAL) && child.IsClass {

--- a/src/ast/decl/enum.go
+++ b/src/ast/decl/enum.go
@@ -53,7 +53,8 @@ func (e *Enum) Syntax(p ast.SyntaxParser) io.Error {
 		for {
 			enumField := field.Enum{
 				Type_: &type_.Composite{
-					Tokens: []token.Token{e.Name_},
+					Context_: p.TypeContext(),
+					Tokens:   []token.Token{e.Name_},
 				},
 			}
 
@@ -96,7 +97,5 @@ func (e *Enum) LinkParents(p ast.SemanticParser, visitedDecls *data.AsyncSet[ast
 	return e.BaseDecl.LinkParents(p, visitedDecls, cycleMap)
 }
 func (e *Enum) Semantic(p ast.SemanticParser) io.Error {
-	p.WrapTypeContext(e)
-	defer p.UnwrapTypeContext()
 	return e.BaseDecl.Semantic(p)
 }

--- a/src/ast/decl/interface.go
+++ b/src/ast/decl/interface.go
@@ -101,7 +101,7 @@ func (i *Interface) LinkParents(p ast.SemanticParser, visitedDecls *data.AsyncSe
 	defer delete(cycleMap, l.String())
 
 	for _, parent := range i.Implements {
-		parentDecl, err := parent.Declaration(p.TypeContext())
+		parentDecl, err := parent.Declaration()
 		if err != nil {
 			return err
 		}
@@ -127,9 +127,6 @@ func (i *Interface) LinkParents(p ast.SemanticParser, visitedDecls *data.AsyncSe
 }
 
 func (i *Interface) Semantic(p ast.SemanticParser) io.Error {
-	p.WrapTypeContext(i)
-	defer p.UnwrapTypeContext()
-
 	// TODO: Handle generic constraints
 	return i.BaseDecl.Semantic(p)
 }

--- a/src/ast/decl/struct.go
+++ b/src/ast/decl/struct.go
@@ -87,9 +87,6 @@ func (s *Struct) LinkParents(p ast.SemanticParser, visitedDecls *data.AsyncSet[a
 	return s.BaseDecl.LinkParents(p, visitedDecls, cycleMap)
 }
 func (s *Struct) Semantic(p ast.SemanticParser) io.Error {
-	p.WrapTypeContext(s)
-	defer p.UnwrapTypeContext()
-
 	// TODO: Handle generic constraints
 	return s.BaseDecl.Semantic(p)
 }

--- a/src/ast/expr/access.go
+++ b/src/ast/expr/access.go
@@ -44,7 +44,7 @@ func (a *Access) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 	right, err := a.Right.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(left, right, &type_.Integer{}); err != nil {
+	} else if _, err := type_.MustExtend(left, right, &type_.Integer{}); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/expr/assign.go
+++ b/src/ast/expr/assign.go
@@ -3,6 +3,7 @@ package expr
 import (
 	"fmt"
 	"geth-cody/ast"
+	"geth-cody/ast/type_"
 	"geth-cody/compile/lexer/token"
 	"geth-cody/io"
 
@@ -70,7 +71,7 @@ func (a *Assign) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 	right, err := a.Right.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(right, left); err != nil {
+	} else if _, err := type_.MustExtend(right, left); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/expr/call.go
+++ b/src/ast/expr/call.go
@@ -46,7 +46,7 @@ func (c *Call) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 		}
 
 		expectedType := ft.ParameterTypes()[i]
-		if _, err := p.TypeContext().MustExtend(t, expectedType); err != nil {
+		if _, err := type_.MustExtend(t, expectedType); err != nil {
 			return nil, err
 		}
 	}

--- a/src/ast/expr/cast.go
+++ b/src/ast/expr/cast.go
@@ -27,7 +27,7 @@ func (c *Cast) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 	}
 
 	if !type_.CastPrimitive(p, t, c.Type) {
-		if _, err := p.TypeContext().MustExtend(c.Type, t); err == nil {
+		if _, err := type_.MustExtend(c.Type, t); err == nil {
 			return nil, err
 		}
 	}

--- a/src/ast/expr/expr.go
+++ b/src/ast/expr/expr.go
@@ -2,6 +2,7 @@ package expr
 
 import (
 	"geth-cody/ast"
+	"geth-cody/ast/type_"
 	"geth-cody/compile/lexer/token"
 	"geth-cody/io"
 
@@ -22,7 +23,7 @@ func (b *Binary) MustBothExtendOne(p ast.SemanticParser, parent ast.Type, parent
 	if err != nil {
 		return nil, err
 	}
-	t, err := p.TypeContext().MustExtend(left, parent, parents...)
+	t, err := type_.MustExtend(left, parent, parents...)
 	if err != nil {
 		return nil, err
 	}
@@ -30,7 +31,7 @@ func (b *Binary) MustBothExtendOne(p ast.SemanticParser, parent ast.Type, parent
 	right, err := b.Right.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(right, t); err != nil {
+	} else if _, err := type_.MustExtend(right, t); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/expr/invert.go
+++ b/src/ast/expr/invert.go
@@ -22,7 +22,7 @@ func (n *Negation) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 		return nil, err
 	}
 
-	if _, err := p.TypeContext().MustExtend(t, &type_.Integer{}, &type_.Float{}); err != nil {
+	if _, err := type_.MustExtend(t, &type_.Integer{}, &type_.Float{}); err != nil {
 		return nil, err
 	}
 
@@ -44,7 +44,7 @@ func (b *Bang) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 		return nil, err
 	}
 
-	if _, err := p.TypeContext().MustExtend(t, &type_.Word{}, &type_.Boolean{}); err != nil {
+	if _, err := type_.MustExtend(t, &type_.Word{}, &type_.Boolean{}); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/expr/modify.go
+++ b/src/ast/expr/modify.go
@@ -25,7 +25,7 @@ func (i *IncrementPrefix) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 		return nil, err
 	}
 
-	if _, err := p.TypeContext().MustExtend(t, &type_.Integer{}); err != nil {
+	if _, err := type_.MustExtend(t, &type_.Integer{}); err != nil {
 		return nil, err
 	}
 
@@ -50,7 +50,7 @@ func (i *IncrementSuffix) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 		return nil, err
 	}
 
-	if _, err := p.TypeContext().MustExtend(t, &type_.Integer{}); err != nil {
+	if _, err := type_.MustExtend(t, &type_.Integer{}); err != nil {
 		return nil, err
 	}
 
@@ -75,7 +75,7 @@ func (d *DecrementPrefix) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 		return nil, err
 	}
 
-	if _, err := p.TypeContext().MustExtend(t, &type_.Integer{}); err != nil {
+	if _, err := type_.MustExtend(t, &type_.Integer{}); err != nil {
 		return nil, err
 	}
 
@@ -100,7 +100,7 @@ func (d *DecrementSuffix) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 		return nil, err
 	}
 
-	if _, err := p.TypeContext().MustExtend(t, &type_.Integer{}); err != nil {
+	if _, err := type_.MustExtend(t, &type_.Integer{}); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/expr/shift.go
+++ b/src/ast/expr/shift.go
@@ -22,14 +22,14 @@ func (r *RightShift) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 	left, err := r.Left.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(left, &type_.Word{}); err != nil {
+	} else if _, err := type_.MustExtend(left, &type_.Word{}); err != nil {
 		return nil, err
 	}
 
 	right, err := r.Right.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(right, &type_.Integer{}); err != nil {
+	} else if _, err := type_.MustExtend(right, &type_.Integer{}); err != nil {
 		return nil, err
 	}
 
@@ -50,14 +50,14 @@ func (l *LeftShift) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 	left, err := l.Left.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(left, &type_.Word{}); err != nil {
+	} else if _, err := type_.MustExtend(left, &type_.Word{}); err != nil {
 		return nil, err
 	}
 
 	right, err := l.Right.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(right, &type_.Integer{}); err != nil {
+	} else if _, err := type_.MustExtend(right, &type_.Integer{}); err != nil {
 		return nil, err
 	}
 
@@ -78,14 +78,14 @@ func (u *UnsignedRightShift) Semantic(p ast.SemanticParser) (ast.Type, io.Error)
 	left, err := u.Left.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(left, &type_.Word{}); err != nil {
+	} else if _, err := type_.MustExtend(left, &type_.Word{}); err != nil {
 		return nil, err
 	}
 
 	right, err := u.Right.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(right, &type_.Integer{}); err != nil {
+	} else if _, err := type_.MustExtend(right, &type_.Integer{}); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/expr/ternary.go
+++ b/src/ast/expr/ternary.go
@@ -67,7 +67,7 @@ func (t *Ternary) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 	cond, err := t.Condition.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(cond, &type_.Boolean{}); err != nil {
+	} else if _, err := type_.MustExtend(cond, &type_.Boolean{}); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/field/enum.go
+++ b/src/ast/field/enum.go
@@ -67,6 +67,6 @@ func (e *Enum) Semantic(p ast.SemanticParser) io.Error {
 		return err
 	}
 
-	_, err = p.TypeContext().MustExtend(t, &type_.Void{})
+	_, err = type_.MustExtend(t, &type_.Void{})
 	return err
 }

--- a/src/ast/field/member.go
+++ b/src/ast/field/member.go
@@ -3,6 +3,7 @@ package field
 import (
 	"fmt"
 	"geth-cody/ast"
+	"geth-cody/ast/type_"
 	"geth-cody/compile/lexer/token"
 	"geth-cody/io"
 )
@@ -74,7 +75,7 @@ func (m *Member) Semantic(p ast.SemanticParser) io.Error {
 		t, err := m.Expr.Semantic(p)
 		if err != nil {
 			return err
-		} else if _, err := p.TypeContext().MustExtend(t, m.Type_); err != nil {
+		} else if _, err := type_.MustExtend(t, m.Type_); err != nil {
 			return err
 		}
 	}

--- a/src/ast/field/method.go
+++ b/src/ast/field/method.go
@@ -3,6 +3,7 @@ package field
 import (
 	"fmt"
 	"geth-cody/ast"
+	"geth-cody/ast/type_"
 	"geth-cody/compile/lexer/token"
 	"geth-cody/io"
 	"geth-cody/strs"
@@ -130,7 +131,7 @@ func (m *Method) Semantic(p ast.SemanticParser) io.Error {
 			).Log(io.Warnf)
 		}
 
-		if _, err := p.TypeContext().MustExtend(t, m.Type.ReturnType()); err != nil {
+		if _, err := type_.MustExtend(t, m.Type.ReturnType()); err != nil {
 			return err
 		}
 	}

--- a/src/ast/file/file.go
+++ b/src/ast/file/file.go
@@ -15,6 +15,13 @@ import (
 type File struct {
 	Imports      map[string]Import
 	Declaration_ ast.Declaration
+
+	Path_   io.Path
+	Project *io.Project
+}
+
+func (f *File) Path() io.Path {
+	return f.Path_
 }
 
 func (f *File) GetImport(name string) (ast.Import, bool) {
@@ -67,13 +74,11 @@ func (f *File) Syntax(p ast.SyntaxParser) io.Error {
 	return err
 }
 
-func Syntax(p ast.SyntaxParser) (ast.File, io.Error) {
-	f := &File{Imports: map[string]Import{}}
-	if err := f.Syntax(p); err != nil {
-		return nil, err
+func New(p ast.SyntaxParser) ast.File {
+	return &File{
+		Imports: map[string]Import{},
+		Path_:   p.Path(),
 	}
-
-	return f, nil
 }
 
 func (f *File) Semantic(p ast.SemanticParser) io.Error {

--- a/src/ast/stmt/for.go
+++ b/src/ast/stmt/for.go
@@ -66,7 +66,7 @@ func (f *For1) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 	t, err := f.Condition.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(t, &type_.Boolean{}); err != nil {
+	} else if _, err := type_.MustExtend(t, &type_.Boolean{}); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/stmt/if.go
+++ b/src/ast/stmt/if.go
@@ -68,7 +68,7 @@ func (i *If) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 	t, err := i.Condition.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(t, &type_.Boolean{}); err != nil {
+	} else if _, err := type_.MustExtend(t, &type_.Boolean{}); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/stmt/panic.go
+++ b/src/ast/stmt/panic.go
@@ -39,7 +39,7 @@ func (p *Panic) Semantic(parser ast.SemanticParser) (ast.Type, io.Error) {
 	t, err := p.Expr.Semantic(parser)
 	if err != nil {
 		return nil, err
-	} else if _, err := parser.TypeContext().MustExtend(t, &type_.String{}); err != nil {
+	} else if _, err := type_.MustExtend(t, &type_.String{}); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/stmt/print.go
+++ b/src/ast/stmt/print.go
@@ -39,7 +39,7 @@ func (p *Print) Semantic(parser ast.SemanticParser) (ast.Type, io.Error) {
 	t, err := p.Expr.Semantic(parser)
 	if err != nil {
 		return nil, err
-	} else if _, err := parser.TypeContext().MustExtend(t, &type_.String{}); err != nil {
+	} else if _, err := type_.MustExtend(t, &type_.String{}); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/stmt/variable.go
+++ b/src/ast/stmt/variable.go
@@ -3,6 +3,7 @@ package stmt
 import (
 	"fmt"
 	"geth-cody/ast"
+	"geth-cody/ast/type_"
 	"geth-cody/compile/lexer/token"
 	"geth-cody/io"
 )
@@ -68,7 +69,7 @@ func (v *Var) Semantic(p ast.SemanticParser) (ast.Type, io.Error) {
 	t, err := v.Expr.Semantic(p)
 	if err != nil {
 		return nil, err
-	} else if _, err := p.TypeContext().MustExtend(t, v.Type_); err != nil {
+	} else if _, err := type_.MustExtend(t, v.Type_); err != nil {
 		return nil, err
 	}
 

--- a/src/ast/type_/array.go
+++ b/src/ast/type_/array.go
@@ -9,6 +9,7 @@ import (
 
 // Array represents an array of elements of another type
 type Array struct {
+	context  ast.TypeContext
 	Type     ast.Type
 	Size     int64
 	EndToken token.Token
@@ -22,25 +23,25 @@ func (a *Array) String() string {
 	return fmt.Sprintf("Array{Type:%s,Size:%d}", a.Type.String(), a.Size)
 }
 
-func (a *Array) ExtendsAsPointer(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
-	return a.Equals(ctx, parent)
+func (a *Array) ExtendsAsPointer(parent ast.Type) (bool, io.Error) {
+	return a.Equals(parent)
 }
 
-func (a *Array) Extends(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
+func (a *Array) Extends(parent ast.Type) (bool, io.Error) {
 	if ptr, ok := parent.(*Pointer); ok {
-		return a.Type.Extends(ctx, ptr.Type)
+		return a.Type.Extends(ptr.Type)
 	}
 
 	return false, nil
 }
 
-func (a *Array) Equals(ctx ast.TypeContext, other ast.Type) (bool, io.Error) {
+func (a *Array) Equals(other ast.Type) (bool, io.Error) {
 	if arr, ok := other.(*Array); ok {
 		if a.Size != arr.Size {
 			return false, nil
 		}
 
-		return a.Type.Equals(ctx, arr.Type)
+		return a.Type.Equals(arr.Type)
 	}
 
 	return false, nil

--- a/src/ast/type_/constraint.go
+++ b/src/ast/type_/constraint.go
@@ -22,13 +22,13 @@ func (s Super) String() string {
 	return fmt.Sprintf("Super{Types:%s}", strs.Strings(s))
 }
 
-func (s Super) ExtendsAsPointer(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
-	return s.Equals(ctx, parent)
+func (s Super) ExtendsAsPointer(parent ast.Type) (bool, io.Error) {
+	return s.Equals(parent)
 }
 
-func (s Super) Extends(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
+func (s Super) Extends(parent ast.Type) (bool, io.Error) {
 	for _, t := range s {
-		if extends, err := ctx.Extends(t, parent); err != nil || !extends {
+		if extends, err := t.Extends(parent); err != nil || !extends {
 			return false, err
 		}
 	}
@@ -36,9 +36,9 @@ func (s Super) Extends(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
 	return true, nil
 }
 
-func (s Super) containsType(ctx ast.TypeContext, t ast.Type) (bool, io.Error) {
+func (s Super) containsType(t ast.Type) (bool, io.Error) {
 	for _, t2 := range s {
-		if ok, err := t2.Equals(ctx, t); err != nil || !ok {
+		if ok, err := t2.Equals(t); err != nil || !ok {
 			return false, err
 		}
 	}
@@ -46,14 +46,14 @@ func (s Super) containsType(ctx ast.TypeContext, t ast.Type) (bool, io.Error) {
 	return true, nil
 }
 
-func (s Super) Equals(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
+func (s Super) Equals(parent ast.Type) (bool, io.Error) {
 	if parentSuper, ok := parent.(Super); ok {
 		if len(s) != len(parentSuper) {
 			return false, nil
 		}
 
 		for _, t := range s {
-			if ok, err := parentSuper.containsType(ctx, t); err != nil || !ok {
+			if ok, err := parentSuper.containsType(t); err != nil || !ok {
 				return false, err
 			}
 		}

--- a/src/ast/type_/generic.go
+++ b/src/ast/type_/generic.go
@@ -10,9 +10,14 @@ import (
 
 // GenericType represents a type with generic type parameters
 type Generic struct {
-	Type         ast.Type
+	Context_     ast.TypeContext
+	Type         ast.DeclType
 	GenericTypes []ast.Type
 	EndToken     token.Token
+}
+
+func (g *Generic) Context() ast.TypeContext {
+	return g.Context_
 }
 
 func (g *Generic) Location() token.Location {
@@ -23,22 +28,32 @@ func (g *Generic) String() string {
 	return fmt.Sprintf("Generic{Type:%s,GenericParameters:%s}", g.Type, strs.Strings(g.GenericTypes))
 }
 
-func (g *Generic) ExtendsAsPointer(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
+func (g *Generic) ExtendsAsPointer(parent ast.Type) (bool, io.Error) {
 	panic("not implemented")
 }
 
-func (g *Generic) Extends(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
-	return g.Equals(ctx, parent)
+func (g *Generic) Extends(parent ast.Type) (bool, io.Error) {
+	return g.Equals(parent)
 }
 
-func (g *Generic) Equals(ctx ast.TypeContext, other ast.Type) (bool, io.Error) {
-	if _, ok := other.(*Generic); ok {
-		panic("not implemented")
+func (g *Generic) Equals(other ast.Type) (bool, io.Error) {
+	gOther, ok := other.(*Generic)
+	if !ok {
+		return false, nil
+	} else if ok, err := g.Type.Equals(gOther.Type); err != nil || !ok {
+		return false, err
 	}
 
-	return false, nil
+	for i, childGenericArg := range g.GenericTypes {
+		parentGenericArg := gOther.GenericTypes[i]
+		if ok, err := childGenericArg.Equals(parentGenericArg); err != nil || !ok {
+			return false, err
+		}
+	}
+
+	return true, nil
 }
 
-func (g *Generic) Declaration(ctx ast.TypeContext) (ast.Declaration, io.Error) {
-	panic("not implemented")
+func (g *Generic) Declaration() (ast.Declaration, io.Error) {
+	return g.Type.Declaration()
 }

--- a/src/ast/type_/iter.go
+++ b/src/ast/type_/iter.go
@@ -8,7 +8,12 @@ import (
 )
 
 type Iter struct {
-	Type ast.Type
+	context ast.TypeContext
+	Type    ast.Type
+}
+
+func (i *Iter) Context() ast.TypeContext {
+	return i.context
 }
 
 func (i *Iter) String() string {
@@ -19,17 +24,17 @@ func (i *Iter) Location() token.Location {
 	return i.Type.Location()
 }
 
-func (i *Iter) ExtendsAsPointer(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
+func (i *Iter) ExtendsAsPointer(parent ast.Type) (bool, io.Error) {
 	panic("not implemented")
 }
 
-func (i *Iter) Extends(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
-	return i.Equals(ctx, parent)
+func (i *Iter) Extends(parent ast.Type) (bool, io.Error) {
+	return i.Equals(parent)
 }
 
-func (i *Iter) Equals(ctx ast.TypeContext, other ast.Type) (bool, io.Error) {
+func (i *Iter) Equals(other ast.Type) (bool, io.Error) {
 	if otherThread, ok := other.(*Thread); ok {
-		return i.Type.Equals(ctx, otherThread.Type)
+		return i.Type.Equals(otherThread.Type)
 	}
 
 	return false, nil

--- a/src/ast/type_/pointer.go
+++ b/src/ast/type_/pointer.go
@@ -21,21 +21,21 @@ func (p *Pointer) String() string {
 	return fmt.Sprintf("Pointer{Type:%s}", p.Type.String())
 }
 
-func (p *Pointer) ExtendsAsPointer(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
-	return p.Equals(ctx, parent)
+func (p *Pointer) ExtendsAsPointer(parent ast.Type) (bool, io.Error) {
+	return p.Equals(parent)
 }
 
-func (p *Pointer) Extends(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
+func (p *Pointer) Extends(parent ast.Type) (bool, io.Error) {
 	if parentPtr, ok := parent.(*Pointer); ok {
-		return p.Type.Extends(ctx, parentPtr.Type)
+		return p.Type.Extends(parentPtr.Type)
 	}
 
 	return false, nil
 }
 
-func (p *Pointer) Equals(ctx ast.TypeContext, other ast.Type) (bool, io.Error) {
+func (p *Pointer) Equals(other ast.Type) (bool, io.Error) {
 	if otherPtr, ok := other.(*Pointer); ok {
-		return p.Type.Equals(ctx, otherPtr.Type)
+		return p.Type.Equals(otherPtr.Type)
 	}
 
 	return false, nil

--- a/src/ast/type_/primitive.go
+++ b/src/ast/type_/primitive.go
@@ -18,15 +18,15 @@ func (p *Primitive[T]) Location() token.Location {
 	return (*token.Token)(p).Location()
 }
 
-func (p *Primitive[T]) ExtendsAsPointer(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
-	return p.Equals(ctx, parent)
+func (p *Primitive[T]) ExtendsAsPointer(parent ast.Type) (bool, io.Error) {
+	return p.Equals(parent)
 }
 
-func (p *Primitive[T]) Extends(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
-	return p.Equals(ctx, parent)
+func (p *Primitive[T]) Extends(parent ast.Type) (bool, io.Error) {
+	return p.Equals(parent)
 }
 
-func (p *Primitive[T]) Equals(ctx ast.TypeContext, other ast.Type) (bool, io.Error) {
+func (p *Primitive[T]) Equals(other ast.Type) (bool, io.Error) {
 	_, ok := other.(*Primitive[T])
 	return ok, nil
 }

--- a/src/ast/type_/tailed.go
+++ b/src/ast/type_/tailed.go
@@ -8,9 +8,13 @@ import (
 )
 
 type Tailed struct {
-	Type     ast.Type
+	Type     ast.DeclType
 	Size     int64
 	EndToken token.Token
+}
+
+func (t *Tailed) Context() ast.TypeContext {
+	return t.Type.Context()
 }
 
 func (t *Tailed) Location() token.Location {
@@ -21,26 +25,26 @@ func (t *Tailed) String() string {
 	return fmt.Sprintf("Tailed{Type:%s,Size:%d}", t.Type.String(), t.Size)
 }
 
-func (t *Tailed) ExtendsAsPointer(ctx ast.TypeContext, other ast.Type) (bool, io.Error) {
+func (t *Tailed) ExtendsAsPointer(other ast.Type) (bool, io.Error) {
 	panic("not implemented")
 }
 
-func (t *Tailed) Extends(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
-	return t.Equals(ctx, parent)
+func (t *Tailed) Extends(parent ast.Type) (bool, io.Error) {
+	return t.Equals(parent)
 }
 
-func (t *Tailed) Equals(ctx ast.TypeContext, other ast.Type) (bool, io.Error) {
+func (t *Tailed) Equals(other ast.Type) (bool, io.Error) {
 	if otherTailed, ok := other.(*Tailed); ok {
 		if t.Size != otherTailed.Size {
 			return false, nil
 		}
 
-		panic("not implemented")
+		return t.Type.Equals(other)
 	}
 
 	return false, nil
 }
 
-func (t *Tailed) Declaration(ctx ast.TypeContext) (ast.Declaration, io.Error) {
-	panic("not implemented")
+func (t *Tailed) Declaration() (ast.Declaration, io.Error) {
+	return t.Type.Declaration()
 }

--- a/src/ast/type_/thread.go
+++ b/src/ast/type_/thread.go
@@ -19,17 +19,17 @@ func (t *Thread) Location() token.Location {
 	return t.Type.Location()
 }
 
-func (t *Thread) ExtendsAsPointer(ctx ast.TypeContext, other ast.Type) (bool, io.Error) {
+func (t *Thread) ExtendsAsPointer(other ast.Type) (bool, io.Error) {
 	panic("not implemented")
 }
 
-func (t *Thread) Extends(ctx ast.TypeContext, parent ast.Type) (bool, io.Error) {
-	return t.Equals(ctx, parent)
+func (t *Thread) Extends(parent ast.Type) (bool, io.Error) {
+	return t.Equals(parent)
 }
 
-func (t *Thread) Equals(ctx ast.TypeContext, other ast.Type) (bool, io.Error) {
+func (t *Thread) Equals(other ast.Type) (bool, io.Error) {
 	if otherThread, ok := other.(*Thread); ok {
-		return t.Type.Equals(ctx, otherThread.Type)
+		return t.Type.Equals(otherThread.Type)
 	}
 
 	return false, nil

--- a/src/compile/semantic/semantic.go
+++ b/src/compile/semantic/semantic.go
@@ -8,31 +8,17 @@ import (
 )
 
 type Parser struct {
-	typeContext *TypeContext
-	scope       *ast.Scope
-	bytecodes   *bytecode.Bytecodes
+	scope     *ast.Scope
+	bytecodes *bytecode.Bytecodes
+	File_     ast.File
 }
 
-func NewParser(fileEntry syntax.FileEntry, projectFiles map[string]*io.Project, fileEntries map[string]syntax.FileEntry) *Parser {
-	return &Parser{
-		typeContext: &TypeContext{
-			fileEntry:    fileEntry,
-			projectFiles: projectFiles,
-			fileEntries:  fileEntries,
-		},
-	}
+func NewParser(file ast.File, symbolMap syntax.SymbolMap) *Parser {
+	panic("")
 }
 
-func (p *Parser) TypeContext() ast.TypeContext {
-	return p.typeContext
-}
-
-func (p *Parser) WrapTypeContext(decl ast.Declaration) {
-	p.typeContext.scope = append(p.typeContext.scope, decl)
-}
-
-func (p *Parser) UnwrapTypeContext() {
-	p.typeContext.scope = p.typeContext.scope[:len(p.typeContext.scope)-1]
+func (p *Parser) File() ast.File {
+	return p.File_
 }
 
 func (p *Parser) Scope() *ast.Scope {
@@ -40,7 +26,7 @@ func (p *Parser) Scope() *ast.Scope {
 }
 
 func (p *Parser) Parse() (*bytecode.Bytecodes, io.Error) {
-	if err := p.typeContext.fileEntry.File.Semantic(p); err != nil {
+	if err := p.File_.Semantic(p); err != nil {
 		return nil, err
 	}
 

--- a/src/compile/syntax/symbolmap.go
+++ b/src/compile/syntax/symbolmap.go
@@ -1,0 +1,11 @@
+package syntax
+
+import (
+	"geth-cody/ast"
+	"geth-cody/io"
+)
+
+type SymbolMap struct {
+	Projects map[string]*io.Project
+	Files    map[string]ast.File
+}

--- a/src/compile/syntax/typecontext.go
+++ b/src/compile/syntax/typecontext.go
@@ -1,28 +1,22 @@
-package semantic
+package syntax
 
 import (
 	"geth-cody/ast"
-	"geth-cody/ast/type_"
 	"geth-cody/compile/lexer/token"
-	"geth-cody/compile/syntax"
 	"geth-cody/io"
 
 	"go.uber.org/zap"
 )
 
 type TypeContext struct {
-	scope        []ast.Declaration
-	fileEntry    syntax.FileEntry
-	projectFiles map[string]*io.Project
-	fileEntries  map[string]syntax.FileEntry
-}
-
-func (tc *TypeContext) Project() *io.Project {
-	return tc.fileEntry.Project
+	file      ast.File
+	project   *io.Project
+	scope     []ast.Declaration
+	symbolMap SymbolMap
 }
 
 func (tc *TypeContext) Dependency(pkg string) (string, bool) {
-	if version, ok := tc.fileEntry.Project.Packages[pkg]; ok {
+	if version, ok := tc.project.Packages[pkg]; ok {
 		return version, ok
 	}
 
@@ -30,9 +24,9 @@ func (tc *TypeContext) Dependency(pkg string) (string, bool) {
 }
 
 func (tc *TypeContext) Declaration(tokens []token.Token) (ast.Declaration, io.Error) {
-	if i, ok := tc.fileEntry.File.GetImport(tokens[0].Value); ok {
-		fileEntry := tc.fileEntries[i.Path().String()]
-		d := fileEntry.File.Declaration()
+	if i, ok := tc.file.GetImport(tokens[0].Value); ok {
+		file := tc.symbolMap.Files[i.Path().String()]
+		d := file.Declaration()
 		for i := 1; i < len(tokens); i++ {
 			decl, ok := d.Declarations()[tokens[i].Value]
 			if !ok {
@@ -68,19 +62,4 @@ scope:
 	}
 
 	return nil, io.NewError("missing declaration", zap.Any("location", tokens[0].Location()))
-}
-
-// Equals returns true if a and b are the same type given a context.
-func (tc *TypeContext) Equals(a, b ast.Type) (bool, io.Error) {
-	return a.Equals(tc, b)
-}
-
-// Extends returns true if child extends parent given a context.
-func (tc *TypeContext) Extends(child, parent ast.Type) (bool, io.Error) {
-	return child.Extends(tc, parent)
-}
-
-// MustExtend returns the parent type that extends child and parent given a context, or an erro if none exists.
-func (tc *TypeContext) MustExtend(child, parent ast.Type, parents ...ast.Type) (ast.Type, io.Error) {
-	return type_.MustExtend(tc, child, parent, parents...)
 }

--- a/src/main.go
+++ b/src/main.go
@@ -27,8 +27,8 @@ func main() {
 		return
 	}
 	io.Infof("[Syntax] End",
-		zap.Strings("file entries", maps.Keys(symbolMap.FileEntries)),
-		zap.Strings("project files", maps.Keys(symbolMap.ProjectFiles)),
+		zap.Strings("file entries", maps.Keys(symbolMap.Files)),
+		zap.Strings("project files", maps.Keys(symbolMap.Projects)),
 	)
 
 	io.Infof("[Semantic] Start")


### PR DESCRIPTION
Include the type context with each parsed type.
Introduce related data in parsers, files, and compilation step methods.