### PR TITLE
Inner type declaration names cannot duplicate generic type parameters

### DIFF
--- a/src/ast/decl/abstract.go
+++ b/src/ast/decl/abstract.go
@@ -79,6 +79,13 @@ func (a *Abstract) Syntax(p ast.SyntaxParser) io.Error {
 		f, err := p.ParseField()
 		if err != nil {
 			return err
+		} else if _, ok := f.(ast.DeclField); ok {
+			if _, exists := a.GenericConstraints[f.Name().Value]; exists {
+				return io.NewError("inner decl name duplicates generic type",
+					zap.Any("decl", f.Name()),
+					zap.Any("location", f.Location()),
+				)
+			}
 		}
 		a.AddField(f)
 	}

--- a/src/ast/decl/class.go
+++ b/src/ast/decl/class.go
@@ -92,6 +92,13 @@ func (c *Class) Syntax(p ast.SyntaxParser) io.Error {
 		f, err := p.ParseField()
 		if err != nil {
 			return err
+		} else if _, ok := f.(ast.DeclField); ok {
+			if _, exists := c.GenericConstraints[f.Name().Value]; exists {
+				return io.NewError("inner decl name duplicates generic type",
+					zap.Any("decl", f.Name()),
+					zap.Any("location", f.Location()),
+				)
+			}
 		} else if f.HasModifier(ast.MOD_VIRTUAL) {
 			return io.NewError("virtual fields are not allowed in classes", zap.Any("field", f.Name()))
 		}

--- a/src/ast/decl/interface.go
+++ b/src/ast/decl/interface.go
@@ -75,6 +75,13 @@ func (i *Interface) Syntax(p ast.SyntaxParser) io.Error {
 		f, err := p.ParseField()
 		if err != nil {
 			return err
+		} else if _, ok := f.(ast.DeclField); ok {
+			if _, exists := i.GenericConstraints[f.Name().Value]; exists {
+				return io.NewError("inner decl name duplicates generic type",
+					zap.Any("decl", f.Name()),
+					zap.Any("location", f.Location()),
+				)
+			}
 		} else if !f.HasModifier(ast.MOD_STATIC) && !f.HasModifier(ast.MOD_VIRTUAL) {
 			return io.NewError("only static and virual fields are allowed in interfaces",
 				zap.Any("field", f.Name()),

--- a/src/ast/decl/struct.go
+++ b/src/ast/decl/struct.go
@@ -69,6 +69,13 @@ func (s *Struct) Syntax(p ast.SyntaxParser) io.Error {
 		f, err := p.ParseField()
 		if err != nil {
 			return err
+		} else if _, ok := f.(ast.DeclField); ok {
+			if _, exists := s.GenericConstraints[f.Name().Value]; exists {
+				return io.NewError("inner decl name duplicates generic type",
+					zap.Any("decl", f.Name()),
+					zap.Any("location", f.Location()),
+				)
+			}
 		} else if f.HasModifier(ast.MOD_VIRTUAL) {
 			return io.NewError("virtual fields are not allowed in structs",
 				zap.Any("field", f.Name()),


### PR DESCRIPTION
Compiling now produces an error if an inner type declaration name duplicates an existing generic type parameter.
For example, the following is now invalid.
```
class List[E] {
    class E {}
}
```
The following is still valid, however.
```
class List[E] {
    class Inner {
        class E {}
    }
}
````