### PR TITLE
Enforce that generic types cannot duplicate import package names

### DIFF
--- a/src/ast/ast.go
+++ b/src/ast/ast.go
@@ -13,6 +13,7 @@ type SyntaxParser interface {
 	AddPath(dependency, path string) (io.Path, io.Error)
 
 	Path() io.Path
+	File() File
 
 	// Peek returns the next token without consuming it.
 	Peek() token.Token

--- a/src/ast/decl/generic.go
+++ b/src/ast/decl/generic.go
@@ -76,7 +76,13 @@ func syntaxGenericConstraints(p ast.SyntaxParser) (map[string]ast.GenericConstra
 			name, err := p.Consume(token.TOK_IDENTIFIER)
 			if err != nil {
 				return nil, err
+			} else if _, exists := p.File().GetImport(name.Value); exists {
+				return nil, io.NewError("generic type cannot duplicate import",
+					zap.Any("name", name),
+					zap.Any("location", name.Location()),
+				)
 			}
+
 			if p.Match(token.TOK_SUBTYPE) {
 				ts, err := syntaxTypes(p)
 				if err != nil {

--- a/src/compile/syntax/syntax.go
+++ b/src/compile/syntax/syntax.go
@@ -48,6 +48,10 @@ func NewParser(tokens []token.Token, project *io.Project, path, mainDirPath io.P
 	}
 }
 
+func (p *Parser) File() ast.File {
+	return p.file
+}
+
 func (p *Parser) Path() io.Path {
 	return p.path
 }


### PR DESCRIPTION
Generic type names can no longer duplicate import package names.
The following is no longer valid:
```
import std("io");

class Node[std] {}
```